### PR TITLE
Create SQLAlchemy models and new endpoints for badges and pet items

### DIFF
--- a/src/PetStoreAPI/app.py
+++ b/src/PetStoreAPI/app.py
@@ -6,6 +6,7 @@ from flask_smorest import Api
 from .models.petitem import PetItemModel
 from .models.store import StoreModel
 from .models.badge import BadgeModel
+from .models.petitems_badges import PetItemBadgeModel
 
 from .init import db
 

--- a/src/PetStoreAPI/models/badge.py
+++ b/src/PetStoreAPI/models/badge.py
@@ -11,3 +11,4 @@ class BadgeModel(db.Model):
     store_id = db.Column(db.Integer, db.ForeignKey("stores.id"), nullable=False)
 
     store = db.relationship("StoreModel", back_populates="badges")
+    petitems = db.relationship("PetItemModel", back_populates="badges", secondary="petitems_badges")

--- a/src/PetStoreAPI/models/petitem.py
+++ b/src/PetStoreAPI/models/petitem.py
@@ -11,3 +11,4 @@ class PetItemModel(db.Model):
     store_id = db.Column(db.Integer, db.ForeignKey("stores.id"), unique=False, nullable=False)
 
     store = db.relationship("StoreModel", back_populates="petitems")
+    badges = db.relationship("BadgeModel", back_populates="petitems", secondary="petitems_badges")

--- a/src/PetStoreAPI/models/petitems_badges.py
+++ b/src/PetStoreAPI/models/petitems_badges.py
@@ -1,0 +1,9 @@
+from ..init import db
+
+
+class PetItemBadgeModel(db.Model):
+    __tablename__ = "petitems_badges"
+
+    id = db.Column(db.Integer, primary_key=True)
+    petitem_id = db.Column(db.Integer, db.ForeignKey("petitems.id"))
+    badge_id = db.Column(db.Integer, db.ForeignKey("badges.id"))

--- a/src/PetStoreAPI/schemas.py
+++ b/src/PetStoreAPI/schemas.py
@@ -31,6 +31,7 @@ class PetItemUpdateSchema(Schema):
 class PetItemSchema(PlainPetItemSchema):
     store_id = fields.Int(required=True, load_only=True)
     store = fields.Nested(PlainStoreSchema(), dump_only=True)
+    badges = fields.List(fields.Nested(PlainBadgeSchema()), dump_only=True)
 
 
 class StoreSchema(PlainStoreSchema):
@@ -41,3 +42,10 @@ class StoreSchema(PlainStoreSchema):
 class BadgeSchema(PlainBadgeSchema):
     store_id = fields.Int(load_only=True)
     store = fields.Nested(PlainStoreSchema(), dump_only=True)
+    petitems = fields.List(fields.Nested(PlainPetItemSchema()), dump_only=True)
+
+
+class BadgeAndPetItemSchema(Schema):
+    message = fields.Str()
+    petitem = fields.Nested(PetItemSchema)
+    badge = fields.Nested(BadgeSchema)


### PR DESCRIPTION
Please review the PR and add comments and feedback. 
Changes made in this PR

Create SQLAlchemy models with PostgreSQL
Add marshmallow schemas for BadgeAndPetItemSchema
many-to-many relationship between PetItem and Badge
Insert models in the database with SQLAlchemy
Get models by ID from the database using SQLAlchemy
Retrieve a list of all models
Delete models using SQLAlchemy
Added Error handling messages
Relationship between Badges and PetItems
One PetItem can have many badges
One Badge can have many PetItems

many-to-many relationships use a secondary table which stores which models of one side are related to which models of the other side.

Example - Table name - petitems_badges
columns
id ,  petitem_id,  badge_id